### PR TITLE
[BUGFIX] std::hash<Node> and std::hash<Location> returns unsigned

### DIFF
--- a/src/Location.h
+++ b/src/Location.h
@@ -71,13 +71,13 @@ inline DomineeringMove Location::to_move() const {
 namespace std {
     template<>
     struct hash<Location> {
-        unsigned operator()(const Location& l) const {
-            unsigned r1 = std::hash<unsigned>()(l.r1);
-            unsigned c1 = std::hash<unsigned>()(l.c1);
-            unsigned r2 = std::hash<unsigned>()(l.r2);
-            unsigned c2 = std::hash<unsigned>()(l.c2);
+        size_t operator()(const Location& l) const {
+            size_t r1{std::hash<unsigned>()(l.r1)};
+            size_t c1{std::hash<unsigned>()(l.c1)};
+            size_t r2{std::hash<unsigned>()(l.r2)};
+            size_t c2{std::hash<unsigned>()(l.c2)};
 
-            unsigned r = ((r1 << 1) ^ r2) >> 1;
+            size_t r{((r1 << 1) ^ r2) >> 1};
             return (((r << 1) ^ c1) >> 1) ^ c2;
         }
     };

--- a/src/Node.h
+++ b/src/Node.h
@@ -155,10 +155,10 @@ inline bool Node::operator!=(const Node& other) const {
 namespace std {
     template<>
     struct hash<Node> {
-        unsigned operator()(const Node& n) const {
-            unsigned t = std::hash<int>()(static_cast<int>(n.team));
-            unsigned l = std::hash<Location>()(n.location);
-            unsigned d = std::hash<unsigned>()(n.depth);
+        size_t operator()(const Node& n) const {
+            size_t t{std::hash<int>()(static_cast<int>(n.team))};
+            size_t l{std::hash<Location>()(n.location)};
+            size_t d{std::hash<unsigned>()(n.depth)};
 
             return (((t << 1) ^ l) >> 1) ^ d;
         }


### PR DESCRIPTION
The size of unsigned is 16 bytes, but `std::hash::result_type` is defined as
size_t. When `sizeof(size_t) > sizeof(unsigned)`, the custom hash functions do
not utilize the full length available for hash keys. Furthermore, they narrow
down the results returned by the other hash functions. The return type is
changed so that it adheres to the standard.

http://www.cplusplus.com/reference/functional/hash/
