### PR TITLE
Add std::hash<DomineeringState>

### DIFF
--- a/src/Searcher.h
+++ b/src/Searcher.h
@@ -154,6 +154,36 @@ inline void Searcher::set_root(const Node& root) {
     this->root = root;
 }
 
+/**
+ * Combine operation of two hash keys. Based on boost::hash_combine.
+ */
+namespace {
+    void hash_combine(std::size_t& h, const std::size_t& v) {
+        h ^= v + 0x9e3779b9 + (h << 6) + (h >> 2);
+    }
+}
+
+/**
+ * Hash function for DomineeringState.
+ * Yes, it is so much more appropriate for this function to reside in
+ * common/DomineeringState.h but since this file is part of the distributed code
+ * base, I did not want to mess around with it.
+ */
+namespace std {
+    template<>
+    struct hash<DomineeringState> {
+        size_t operator()(const DomineeringState& ds) const {
+            size_t h = 0;
+            for (auto&& c : *ds.getBoard1D()) {
+                if (c == ds.EMPTYSYM) {
+                    hash_combine(h, std::hash<char>()(c));
+                }
+            }
+            return h;
+        }
+    };
+} // namespace std
+
 #endif /* end of include guard */
 
 /* vim: tw=78:et:ts=4:sts=4:sw=4 */

--- a/src/common/BoardGameState.h
+++ b/src/common/BoardGameState.h
@@ -38,6 +38,10 @@ public:
     
     BoardGameState& operator = (BoardGameState &&other);
     
+    bool operator==(const BoardGameState& other);
+
+    bool operator!=(const BoardGameState& other);
+
     /**
      * check if a position is valid on the board
      * @param r the row
@@ -102,5 +106,23 @@ protected:
                    char awaySym, char emptySym);
 };
 
+inline bool BoardGameState::operator==(const BoardGameState& other) {
+    if (board.size() != other.board.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < board.size(); i++) {
+        if ((board[i] == EMPTYSYM || other.board[i] == EMPTYSYM)
+            && board[i] != other.board[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+inline bool BoardGameState::operator!=(const BoardGameState& other) {
+    return !(board == other.board);
+}
 
 #endif /* defined(__CSE486AIProject__BoardGameState__) */


### PR DESCRIPTION
This change adds a hash function in the std namespace that specializes
DomineeringState. It also adds `operator==` and `operator!=` for
BoardGameState, which DomineeringState inherits from. This allows comparing
two states to check if they are the same. Two states are considered same if
the empty spaces match.
