### PR TITLE
Don't return scores in search_under

### DIFF
--- a/src/Evaluators.h
+++ b/src/Evaluators.h
@@ -214,6 +214,7 @@ struct EvalAwayOpen : public Evaluator {
 struct ClearMarks : public Evaluator {
     score_t operator()(DS* state) {
         clear_marks(*state);
+        return 0;
     }
 };
 
@@ -226,13 +227,13 @@ static const std::vector<std::pair<EvalScore, EvalFactor>> evaluators = {
         // First count the reserved, marking each reserved spot so that we
         // don't double count.
         std::make_pair(EvalHomeReserved(), [](const DS& state) {
-                       return state.getWho() == Who::HOME ? 2 : 0;
+                       return 2;
                        })
     },
     {
         // Then count the remaining open spots for HOME
         std::make_pair(EvalHomeOpen(), [](const DS& state) {
-                       return state.getWho() == Who::HOME ? 1 : -1;
+                       return 1;
                        })
     },
     {
@@ -245,13 +246,13 @@ static const std::vector<std::pair<EvalScore, EvalFactor>> evaluators = {
         // First count the reserved, marking each reserved spot so that we
         // don't double count.
         std::make_pair(EvalAwayReserved(), [](const DS& state) {
-                       return state.getWho() == Who::HOME ? 0 : -2;
+                       return -2;
                        })
     },
     {
         // Then count the remaining open spots for HOME
         std::make_pair(EvalAwayOpen(), [](const DS& state) {
-                       return state.getWho() == Who::HOME ? -1 : 1;
+                       return -1;
                        })
     },
     {

--- a/src/Searcher.cpp
+++ b/src/Searcher.cpp
@@ -48,6 +48,7 @@ Searcher& Searcher::operator=(Searcher&& other) {
 
 Node Searcher::search(const DomineeringState& state,
         const unsigned depth_limit) {
+    // Initialize best moves
     best_moves.resize(depth_limit + 1);
     std::fill(best_moves.begin(), best_moves.end(), Node());
 
@@ -64,19 +65,20 @@ Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
         return evaluate(current_state);
     }
 
-    std::vector<Node> expanded;
-    auto exp = ordered_moves.find(current_state);
-    if (parent.depth == 0 && exp != ordered_moves.end()) {
-        expanded = exp->second;
+    std::vector<Node> children;
+    auto ordered = ordered_moves.find(current_state);
+    // Use move-ordered children if possible
+    if (parent.depth == 0 && ordered != ordered_moves.end()) {
+        children = ordered->second;
     }
     else {
-        expanded = expand(parent, current_state);
+        children = expand(parent, current_state);
     }
 
     Node& current_best = best_moves[parent.depth];
 
     // `parent' is a terminal node
-    if (expanded.empty()) {
+    if (children.empty()) {
         current_best.set_as_terminal();
         // POS_INF or NEG_INF
         return current_best.score();
@@ -94,7 +96,7 @@ Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
     next_state.togglePlayer();
 
     // create a branch queue vector for every possible future root node
-    for (const Node& child : expanded) {
+    for (const Node& child : children) {
         // Update board to simulate placing the child.
         // Done so that we don't need to make a copy of state for each child.
         tap(child, next_state);
@@ -129,7 +131,6 @@ Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
             current_best.set_score(result);
 
             ab.update_if_needed(result, parent.team);
-
             if (ab.can_prune(result, parent.team)) {
                 break;
             }
@@ -137,11 +138,11 @@ Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
     }
 
     // The move that our opponent made is at depth 0. We make the best move at
-    // depth 1. Our opponent will make one of the moves expanded at depth 2.
-    // Thus, we want to store the children expanded at depth 2, which will be
+    // depth 1. Our opponent will make one of the moves children at depth 2.
+    // Thus, we want to store the children children at depth 2, which will be
     // our next moves, and move order them so that we maximize pruning.
     if (parent.depth == 2) {
-        ordered_moves[current_state] = expanded;
+        ordered_moves[current_state] = children;
     }
 
     return current_best.score();

--- a/src/Searcher.cpp
+++ b/src/Searcher.cpp
@@ -58,11 +58,15 @@ Node Searcher::search(const DomineeringState& state,
     return best_moves.front();
 }
 
-Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
-        const DomineeringState& current_state, const unsigned depth_limit) {
+void Searcher::search_under(const Node& parent,
+                            AlphaBeta ab,
+                            const DomineeringState& current_state,
+                            const unsigned depth_limit) {
     // Base case
     if (parent.depth >= depth_limit) {
-        return evaluate(current_state);
+        best_moves[parent.depth] = parent;
+        best_moves[parent.depth].set_score(evaluate(current_state));
+        return;
     }
 
     std::vector<Node> children;
@@ -80,11 +84,9 @@ Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
     // `parent' is a terminal node
     if (children.empty()) {
         current_best.set_as_terminal();
-        // POS_INF or NEG_INF
-        return current_best.score();
+        return;
     }
 
-    DomineeringState next_state(current_state);
     /*
      * Reset the score to POS_INF or NEG_INF depending on which team this node
      * belongs to.
@@ -93,6 +95,7 @@ Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
                            ? AlphaBeta::NEG_INF
                            : AlphaBeta::POS_INF);
 
+    DomineeringState next_state{current_state};
     next_state.togglePlayer();
 
     // create a branch queue vector for every possible future root node
@@ -101,27 +104,21 @@ Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
         // Done so that we don't need to make a copy of state for each child.
         tap(child, next_state);
 
-        Evaluator::score_t result;
-        bool found;
+        // bool found;
         // Check for transpositions that were already explored
-        std::tie(result, found) = tp_table.check(next_state);
-        if (!found) {
+        // std::tie(result, found) = tp_table.check(next_state);
+        // if (!found) {
             // Recursive call
-            result = search_under(child, ab, next_state, depth_limit);
+            search_under(child, ab, next_state, depth_limit);
             // Add result to transposition table
-            tp_table.insert(next_state, result);
-        }
+        //     tp_table.insert(next_state, result);
+        // }
 
         // Rewind to board before placing the child
         untap(child, next_state);
 
-        // Found path to a terminal state
-        if (result == AlphaBeta::POS_INF || result == AlphaBeta::NEG_INF) {
-            current_best = std::move(child);
-            current_best.set_as_terminal();
-            // POS_INF or NEG_INF
-            return current_best.score();
-        }
+        const Node& next_move{best_moves[parent.depth + 1]};
+        const Evaluator::score_t result = next_move.score();
 
         bool result_better = parent.team == Who::HOME
             ? result > current_best.score()
@@ -132,7 +129,7 @@ Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
 
             ab.update_if_needed(result, parent.team);
             if (ab.can_prune(result, parent.team)) {
-                break;
+                return;
             }
         }
     }
@@ -145,7 +142,7 @@ Evaluator::score_t Searcher::search_under(const Node& parent, AlphaBeta ab,
         ordered_moves[current_state] = children;
     }
 
-    return current_best.score();
+    return;
 }
 
 Evaluator::score_t Searcher::evaluate(const DomineeringState& state) {
@@ -165,25 +162,28 @@ Evaluator::score_t Searcher::evaluate(const DomineeringState& state) {
 /* Private methods */
 
 std::vector<Node> Searcher::expand(const Node& parent,
-        const DomineeringState& state) {
-    // Player has been toggled already
-    Who my_team = state.getWho();
-    unsigned my_depth = parent.depth + 1;
+        const DomineeringState& current_state) {
+    // Toggle player
+    Who child_team = parent.team == Who::HOME ? Who::AWAY : Who::HOME;
+    unsigned child_depth = parent.depth + 1;
     std::vector<Node> children;
 
     // Create one instance and modify the values so that we don't have to
     // instantiate a ton of vectors in GameMove constructor.
-    DomineeringMove my_move(0, 0, 0, 0);
-    for (unsigned r1 = 0; r1 < state.ROWS; r1++) {
-        for (unsigned c1 = 0; c1 < state.COLS; c1++) {
+    DomineeringMove parent_move{0, 0, 0, 0};
+    for (unsigned r1 = 0; r1 < current_state.ROWS; r1++) {
+        for (unsigned c1 = 0; c1 < current_state.COLS; c1++) {
             // Home places horizontally, Away places vertically
-            unsigned r2 = my_team == Who::HOME ? r1 : r1 + 1;
-            unsigned c2 = my_team == Who::HOME ? c1 + 1 : c1;
+            unsigned r2 = parent.team == Who::HOME ? r1 : r1 + 1;
+            unsigned c2 = parent.team == Who::HOME ? c1 + 1 : c1;
 
-            my_move.setMv(r1, c1, r2, c2);
+            parent_move.setMv(r1, c1, r2, c2);
 
-            if (state.moveOK(my_move)) {
-                children.push_back(Node(my_team, my_depth, Location(my_move)));
+            if (current_state.moveOK(parent_move)) {
+                // Note: my_move is HOW I got to this state i.e. parent's move
+                children.push_back(Node(child_team,
+                                        child_depth,
+                                        Location(parent_move)));
             }
         }
     }
@@ -204,7 +204,8 @@ void Searcher::move_order(Who team) {
 }
 
 void Searcher::tap(const Node& node, DomineeringState& state) {
-    char c = node.team == Who::HOME ? state.HOMESYM : state.AWAYSYM;
+    // To reflect the parent's team, flip the symbols
+    char c = node.team == Who::HOME ? state.AWAYSYM : state.HOMESYM;
     state.setCell(node.location.r1, node.location.c1, c);
     state.setCell(node.location.r2, node.location.c2, c);
 }

--- a/src/Searcher.h
+++ b/src/Searcher.h
@@ -64,8 +64,7 @@ public:
     Node search(const DomineeringState& state, const unsigned depth_limit);
 
     /**
-     * Searches under the given node and returns the best move for that
-     * branch.
+     * Searches under the given node.
      * This method populates the `best_moves' vector, so that the calling
      * method can look that up to find what the best move is for a certain
      * depth.
@@ -77,13 +76,11 @@ public:
      * \param[in] state current state of the game.
      *
      * \param[in] depth_limit the maximum depth to go down.
-     *
-     * \return the score that results from the best move.
      */
-    Evaluator::score_t search_under(const Node& parent,
-                                    AlphaBeta ab,
-                                    const DomineeringState& state,
-                                    const unsigned depth_limit);
+    void search_under(const Node& parent,
+                      AlphaBeta ab,
+                      const DomineeringState& state,
+                      const unsigned depth_limit);
 
     /**
      * Given a state (i.e. the current board), this method evaluates and gives
@@ -132,12 +129,16 @@ private:
      *
      * \param[in] parent the node to expand.
      *
-     * \param[in] current_state the state of the current game.
+     * \param[in] current_state the state of the current game. Children are
+     *                          expanded by placing the parent's team's
+     *                          dominoes onto current_state and checking if
+     *                          that is a valid move or not.
      *
-     * \return a vector of the expanded nodes.
+     * \return a vector of the expanded nodes. Note that the team of the nodes
+     *         is the opposite of the parent.
      */
     std::vector<Node> expand(const Node& parent,
-            const DomineeringState& current_state);
+                             const DomineeringState& current_state);
 
     /**
      * Does move ordering to the vectors of nodes stored as values in the


### PR DESCRIPTION
This PR makes the change of not returning the score but rather updates the moves in the `best_moves` vector.
